### PR TITLE
Ensure coin toss reveal timers fire reliably

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import AuthenticationGateway from './components/AuthenticationGateway'
 import AdminDashboard from './components/AdminDashboard'
 import TeamDashboard from './components/TeamDashboard'
@@ -127,6 +127,7 @@ export default function App() {
   const [matchHistory, setMatchHistory] = useState([])
   const [recentResult, setRecentResult] = useState(null)
   const [authError, setAuthError] = useState(null)
+  const revealTimersRef = useRef(new Map())
 
   const activeTeam = useMemo(() => {
     if (session.type !== 'team') return null
@@ -203,31 +204,28 @@ export default function App() {
   }
 
   const handleFlipCoin = (matchId) => {
-    let shouldScheduleReveal = false
+    setMatches((previous) => {
+      const matchToFlip = previous.find((match) => match.id === matchId)
+      if (!matchToFlip || matchToFlip.status !== 'coin-toss') {
+        return previous
+      }
 
-    setMatches((previous) =>
-      previous.map((match) => {
-        if (match.id !== matchId) return match
-        if (match.coinToss.status !== 'ready') return match
-        shouldScheduleReveal = true
-        return {
-          ...match,
-          coinToss: {
-            ...match.coinToss,
-            status: 'flipping',
-            winnerId: null,
-            decision: null,
-          },
-        }
-      }),
-    )
+      if (matchToFlip.coinToss.status !== 'ready') {
+        return previous
+      }
 
-    if (shouldScheduleReveal) {
-      setTimeout(() => {
-        setMatches((previous) =>
-          previous.map((match) => {
+      const timers = revealTimersRef.current
+      const existingTimer = timers.get(matchId)
+      if (existingTimer) {
+        clearTimeout(existingTimer)
+      }
+
+      const timerId = setTimeout(() => {
+        revealTimersRef.current.delete(matchId)
+        setMatches((current) =>
+          current.map((match) => {
             if (match.id !== matchId) return match
-            if (match.coinToss.status !== 'flipping') return match
+            if (match.status !== 'coin-toss') return match
             const winnerId = match.teams[Math.floor(Math.random() * match.teams.length)]
             return {
               ...match,
@@ -239,9 +237,23 @@ export default function App() {
             }
           }),
         )
-
       }, 1800)
-    }
+
+      timers.set(matchId, timerId)
+
+      return previous.map((match) => {
+        if (match.id !== matchId) return match
+        return {
+          ...match,
+          coinToss: {
+            ...match.coinToss,
+            status: 'flipping',
+            winnerId: null,
+            decision: null,
+          },
+        }
+      })
+    })
   }
 
   const handleSelectFirst = (deciderId, matchId, firstTeamId) => {
@@ -275,6 +287,13 @@ export default function App() {
   }
 
   const finalizeMatch = (match) => {
+    const timers = revealTimersRef.current
+    const existingTimer = timers.get(match.id)
+    if (existingTimer) {
+      clearTimeout(existingTimer)
+      timers.delete(match.id)
+    }
+
     const [teamAId, teamBId] = match.teams
     const teamAScore = match.scores[teamAId]
     const teamBScore = match.scores[teamBId]


### PR DESCRIPTION
## Summary
- only start a coin toss flip when the match is still in its coin-toss phase and ready
- schedule and store the reveal timer atomically with the state change so the reveal always fires even in strict mode re-renders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db61f0764c8320a9935760638cf4ab