### PR TITLE
Add tournament data models and admin seeding routes

### DIFF
--- a/backend/src/db/models/index.js
+++ b/backend/src/db/models/index.js
@@ -1,0 +1,8 @@
+export { default as Team } from './team.js'
+export { default as Moderator } from './moderator.js'
+export { default as Question } from './question.js'
+export { default as Tournament } from './tournament.js'
+export { default as Stage } from './stage.js'
+export { default as Match } from './match.js'
+export { default as LiveMatch } from './liveMatch.js'
+export { teamRecordSchema } from './teamRecord.js'

--- a/backend/src/db/models/liveMatch.js
+++ b/backend/src/db/models/liveMatch.js
@@ -1,0 +1,39 @@
+import mongoose from 'mongoose'
+
+const { Schema, model } = mongoose
+
+const eventSchema = new Schema(
+  {
+    timestamp: { type: Date, default: Date.now },
+    type: { type: String, required: true },
+    payload: { type: Schema.Types.Mixed },
+  },
+  { _id: false }
+)
+
+const liveMatchSchema = new Schema(
+  {
+    match: { type: Schema.Types.ObjectId, ref: 'Match', required: true },
+    matchRefId: { type: String, required: true, unique: true },
+    streamKey: { type: String },
+    state: { type: String, enum: ['waiting', 'live', 'paused', 'completed'], default: 'waiting' },
+    scoreboard: {
+      homeScore: { type: Number, default: 0 },
+      awayScore: { type: Number, default: 0 },
+      period: { type: String },
+    },
+    events: { type: [eventSchema], default: [] },
+  },
+  { timestamps: true }
+)
+
+liveMatchSchema.index({ matchRefId: 1 }, { unique: true })
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof liveMatchSchema>} LiveMatch
+ */
+
+const LiveMatch = model('LiveMatch', liveMatchSchema)
+
+export default LiveMatch
+export { liveMatchSchema }

--- a/backend/src/db/models/match.js
+++ b/backend/src/db/models/match.js
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose'
+
+const { Schema, model } = mongoose
+
+const resultSchema = new Schema(
+  {
+    homeScore: { type: Number, default: 0 },
+    awayScore: { type: Number, default: 0 },
+    winnerTeam: { type: Schema.Types.ObjectId, ref: 'Team' },
+  },
+  { _id: false }
+)
+
+const matchSchema = new Schema(
+  {
+    matchRefId: { type: String, trim: true },
+    tournament: { type: Schema.Types.ObjectId, ref: 'Tournament', required: true },
+    stage: { type: Schema.Types.ObjectId, ref: 'Stage' },
+    homeTeam: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+    awayTeam: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+    scheduledAt: { type: Date },
+    status: { type: String, enum: ['scheduled', 'live', 'completed'], default: 'scheduled' },
+    result: resultSchema,
+    metadata: { type: Map, of: Schema.Types.Mixed },
+  },
+  { timestamps: true }
+)
+
+matchSchema.index({ matchRefId: 1 }, { sparse: true })
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof matchSchema>} Match
+ */
+
+const Match = model('Match', matchSchema)
+
+export default Match
+export { matchSchema }

--- a/backend/src/db/models/moderator.js
+++ b/backend/src/db/models/moderator.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose'
+
+const { Schema, model } = mongoose
+
+const moderatorSchema = new Schema(
+  {
+    loginId: { type: String, required: true, trim: true, unique: true },
+    email: { type: String, required: true, lowercase: true, trim: true },
+    displayName: { type: String, trim: true },
+    role: { type: String, enum: ['moderator', 'admin'], default: 'moderator' },
+    active: { type: Boolean, default: true },
+    permissions: [{ type: String }],
+  },
+  { timestamps: true }
+)
+
+moderatorSchema.index({ loginId: 1 }, { unique: true })
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof moderatorSchema>} Moderator
+ */
+
+const Moderator = model('Moderator', moderatorSchema)
+
+export default Moderator
+export { moderatorSchema }

--- a/backend/src/db/models/question.js
+++ b/backend/src/db/models/question.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose'
+
+const { Schema, model } = mongoose
+
+const answerOptionSchema = new Schema(
+  {
+    key: { type: String, required: true },
+    text: { type: String, required: true },
+  },
+  { _id: false }
+)
+
+const questionSchema = new Schema(
+  {
+    category: { type: String, required: true, trim: true },
+    difficulty: { type: String, enum: ['easy', 'medium', 'hard'], default: 'easy' },
+    prompt: { type: String, required: true },
+    answers: { type: [answerOptionSchema], default: undefined },
+    correctAnswerKey: { type: String, required: true },
+    explanation: { type: String },
+    tags: [{ type: String }],
+    lastUsedAt: { type: Date },
+  },
+  { timestamps: true }
+)
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof questionSchema>} Question
+ */
+
+const Question = model('Question', questionSchema)
+
+export default Question
+export { questionSchema }

--- a/backend/src/db/models/stage.js
+++ b/backend/src/db/models/stage.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose'
+import { teamRecordSchema } from './teamRecord.js'
+
+const { Schema, model } = mongoose
+
+const stageSchema = new Schema(
+  {
+    tournament: { type: Schema.Types.ObjectId, ref: 'Tournament', required: true },
+    name: { type: String, required: true },
+    type: { type: String, enum: ['group', 'knockout', 'play-in', 'final'], default: 'group' },
+    order: { type: Number, default: 0 },
+    bestOf: { type: Number, default: 1 },
+    teamRecords: { type: [teamRecordSchema], default: [] },
+    matches: [{ type: Schema.Types.ObjectId, ref: 'Match' }],
+  },
+  { timestamps: true }
+)
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof stageSchema>} Stage
+ */
+
+const Stage = model('Stage', stageSchema)
+
+export default Stage
+export { stageSchema }

--- a/backend/src/db/models/team.js
+++ b/backend/src/db/models/team.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose'
+
+const { Schema, model } = mongoose
+
+const teamSchema = new Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    loginId: { type: String, required: true, trim: true, unique: true },
+    region: { type: String, trim: true },
+    seed: { type: Number },
+    avatarUrl: { type: String },
+    metadata: { type: Map, of: Schema.Types.Mixed },
+  },
+  { timestamps: true }
+)
+
+teamSchema.index({ loginId: 1 }, { unique: true })
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof teamSchema>} Team
+ */
+
+const Team = model('Team', teamSchema)
+
+export default Team
+export { teamSchema }

--- a/backend/src/db/models/teamRecord.js
+++ b/backend/src/db/models/teamRecord.js
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose'
+
+const { Schema } = mongoose
+
+const teamRecordSchema = new Schema(
+  {
+    team: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+    wins: { type: Number, default: 0 },
+    losses: { type: Number, default: 0 },
+    points: { type: Number, default: 0 },
+    eliminated: { type: Boolean, default: false },
+    initialBye: { type: Boolean, default: false },
+  },
+  { _id: false }
+)
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof teamRecordSchema>} TeamRecord
+ */
+
+export { teamRecordSchema }

--- a/backend/src/db/models/tournament.js
+++ b/backend/src/db/models/tournament.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose'
+import { teamRecordSchema } from './teamRecord.js'
+
+const { Schema, model } = mongoose
+
+const tournamentSchema = new Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    slug: { type: String, trim: true },
+    status: {
+      type: String,
+      enum: ['draft', 'upcoming', 'live', 'completed', 'archived'],
+      default: 'draft',
+      index: true,
+    },
+    description: { type: String },
+    startDate: { type: Date },
+    endDate: { type: Date },
+    teams: [{ type: Schema.Types.ObjectId, ref: 'Team' }],
+    stages: [{ type: Schema.Types.ObjectId, ref: 'Stage' }],
+    standings: { type: [teamRecordSchema], default: [] },
+    settings: {
+      bracketSize: { type: Number },
+      doubleElimination: { type: Boolean, default: false },
+    },
+  },
+  { timestamps: true }
+)
+
+/**
+ * @typedef {import('mongoose').InferSchemaType<typeof tournamentSchema>} Tournament
+ */
+
+const Tournament = model('Tournament', tournamentSchema)
+
+export default Tournament
+export { tournamentSchema }

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,60 @@
+import { Router } from 'express'
+import { Moderator, Question, Team } from '../db/models/index.js'
+import { seedModerators, seedQuestions, seedTeams } from '../seeds/initialData.js'
+
+const adminRouter = Router()
+
+const upsertByLoginId = async (Model, payload, uniqueKey = 'loginId') => {
+  const records = Array.isArray(payload) && payload.length > 0 ? payload : []
+  if (records.length === 0) return { matchedCount: 0, upsertedCount: 0 }
+
+  const operations = records.map((doc) => ({
+    updateOne: {
+      filter: { [uniqueKey]: doc[uniqueKey] },
+      update: { $setOnInsert: doc },
+      upsert: true,
+    },
+  }))
+
+  const result = await Model.bulkWrite(operations, { ordered: false })
+  return { matchedCount: result.matchedCount || 0, upsertedCount: result.upsertedCount || 0 }
+}
+
+adminRouter.post('/seed/teams', async (req, res, next) => {
+  try {
+    const records = req.body?.teams ?? seedTeams
+    const summary = await upsertByLoginId(Team, records)
+    res.json({ message: 'Teams seeded', ...summary })
+  } catch (error) {
+    next(error)
+  }
+})
+
+adminRouter.post('/seed/moderators', async (req, res, next) => {
+  try {
+    const records = req.body?.moderators ?? seedModerators
+    const summary = await upsertByLoginId(Moderator, records)
+    res.json({ message: 'Moderators seeded', ...summary })
+  } catch (error) {
+    next(error)
+  }
+})
+
+adminRouter.post('/seed/questions', async (req, res, next) => {
+  try {
+    const questions = Array.isArray(req.body?.questions) && req.body.questions.length > 0 ? req.body.questions : seedQuestions
+    const operations = questions.map((doc) => ({
+      updateOne: {
+        filter: { prompt: doc.prompt },
+        update: { $setOnInsert: doc },
+        upsert: true,
+      },
+    }))
+    const result = await Question.bulkWrite(operations, { ordered: false })
+    res.json({ message: 'Questions seeded', matchedCount: result.matchedCount || 0, upsertedCount: result.upsertedCount || 0 })
+  } catch (error) {
+    next(error)
+  }
+})
+
+export default adminRouter

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { accounts, constants } from '../config/index.js'
+import adminRouter from './admin.js'
 
 const router = Router()
 
@@ -20,5 +21,7 @@ router.get('/accounts/seed', (req, res) => {
     admins: accounts.adminAccounts.map(({ email }) => ({ email })),
   })
 })
+
+router.use('/admin', adminRouter)
 
 export default router

--- a/backend/src/seeds/initialData.js
+++ b/backend/src/seeds/initialData.js
@@ -1,0 +1,51 @@
+export const seedTeams = [
+  { name: 'North City Bulls', loginId: 'team-north-bulls', region: 'North', seed: 1 },
+  { name: 'East Harbor Jets', loginId: 'team-east-jets', region: 'East', seed: 2 },
+  { name: 'South Bay Guardians', loginId: 'team-south-guardians', region: 'South', seed: 3 },
+]
+
+export const seedModerators = [
+  {
+    loginId: 'mod-avery',
+    email: 'avery.moderator@financialfootball.test',
+    displayName: 'Avery',
+    role: 'moderator',
+  },
+  {
+    loginId: 'mod-river',
+    email: 'river.moderator@financialfootball.test',
+    displayName: 'River',
+    role: 'moderator',
+  },
+]
+
+export const seedQuestions = [
+  {
+    category: 'Budgeting',
+    difficulty: 'easy',
+    prompt: 'What is the purpose of creating an emergency fund?',
+    answers: [
+      { key: 'A', text: 'To cover unexpected expenses without debt' },
+      { key: 'B', text: 'To invest in high-risk stocks' },
+      { key: 'C', text: 'To pay for entertainment only' },
+      { key: 'D', text: 'To increase your credit card limit' },
+    ],
+    correctAnswerKey: 'A',
+    explanation: 'Emergency funds keep teams financially resilient during surprises.',
+    tags: ['savings'],
+  },
+  {
+    category: 'Credit',
+    difficulty: 'medium',
+    prompt: 'Which action is most likely to improve a credit score?',
+    answers: [
+      { key: 'A', text: 'Maxing out every credit card' },
+      { key: 'B', text: 'Making on-time payments' },
+      { key: 'C', text: 'Closing the oldest account' },
+      { key: 'D', text: 'Ignoring credit reports' },
+    ],
+    correctAnswerKey: 'B',
+    explanation: 'Consistent on-time payments demonstrate reliability.',
+    tags: ['credit'],
+  },
+]


### PR DESCRIPTION
## Summary
- add mongoose schemas and JSDoc typedefs for teams, moderators, tournaments, stages, and matches
- include embedded team record data plus indexes for loginId, tournament status, and matchRefId
- create seed data plus admin routes to upsert teams, moderators, and questions until a CMS is available

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dae22c704832087a52b8b07affef6)