### PR TITLE
Add authentication routes and role-based middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
@@ -399,6 +400,20 @@
       "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/binary-extensions": {
@@ -1869,6 +1884,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "description": "API and realtime server for the Financial Football app",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",

--- a/backend/src/config/security.js
+++ b/backend/src/config/security.js
@@ -6,7 +6,20 @@ const security = {
     refreshSecret: process.env.JWT_REFRESH_SECRET || 'dev-financial-football-refresh',
     expiresIn: process.env.JWT_EXPIRATION || '1h',
   },
-  publicRoutes: ['/health', '/api/health', '/auth/login', '/api/auth/login'],
+  publicRoutes: [
+    '/health',
+    '/api/health',
+    '/auth/login',
+    '/api/auth/login',
+    '/auth/team',
+    '/auth/moderator',
+    '/auth/admin',
+    '/auth/logout',
+    '/api/auth/team',
+    '/api/auth/moderator',
+    '/api/auth/admin',
+    '/api/auth/logout',
+  ],
   allowedOrigins: process.env.CORS_ORIGIN
     ? process.env.CORS_ORIGIN.split(',').map((origin) => origin.trim())
     : defaultOrigins,

--- a/backend/src/db/models/moderator.js
+++ b/backend/src/db/models/moderator.js
@@ -6,6 +6,7 @@ const moderatorSchema = new Schema(
   {
     loginId: { type: String, required: true, trim: true, unique: true },
     email: { type: String, required: true, lowercase: true, trim: true },
+    passwordHash: { type: String, required: true, select: false },
     displayName: { type: String, trim: true },
     role: { type: String, enum: ['moderator', 'admin'], default: 'moderator' },
     active: { type: Boolean, default: true },

--- a/backend/src/db/models/team.js
+++ b/backend/src/db/models/team.js
@@ -6,6 +6,7 @@ const teamSchema = new Schema(
   {
     name: { type: String, required: true, trim: true },
     loginId: { type: String, required: true, trim: true, unique: true },
+    passwordHash: { type: String, required: true, select: false },
     region: { type: String, trim: true },
     seed: { type: Number },
     avatarUrl: { type: String },

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -2,29 +2,85 @@ import jwt from 'jsonwebtoken'
 import { security } from '../config/index.js'
 
 const { jwt: jwtConfig, publicRoutes } = security
+const tokenBlacklist = new Set()
 
-const authMiddleware = (req, res, next) => {
-  const isPublicRoute = publicRoutes.some((route) => req.path.startsWith(route))
+const isPublicRoute = (path = '') => publicRoutes.some((route) => path.startsWith(route))
 
-  if (isPublicRoute) {
-    return next()
+const refreshSessionContext = (req, payload) => {
+  req.user = payload
+  req.session = {
+    userId: payload.sub,
+    role: payload.role,
+    loginId: payload.loginId,
   }
+}
 
+const isTokenBlacklisted = (token) => tokenBlacklist.has(token)
+
+const addTokenToBlacklist = (token) => {
+  tokenBlacklist.add(token)
+  const decoded = jwt.decode(token)
+  if (decoded?.exp) {
+    const ttl = decoded.exp * 1000 - Date.now()
+    if (ttl > 0) {
+      setTimeout(() => tokenBlacklist.delete(token), ttl)
+    }
+  }
+}
+
+const authenticateRequest = (req, res) => {
   const authHeader = req.headers.authorization
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return res.status(401).json({ message: 'Authorization token missing' })
+    res.status(401).json({ message: 'Authorization token missing' })
+    return null
+  }
+
+  const token = authHeader.replace('Bearer ', '')
+  if (isTokenBlacklisted(token)) {
+    res.status(401).json({ message: 'Session has been terminated' })
+    return null
   }
 
   try {
-    const token = authHeader.replace('Bearer ', '')
-    req.user = jwt.verify(token, jwtConfig.secret)
+    const payload = jwt.verify(token, jwtConfig.secret)
+    refreshSessionContext(req, payload)
+    return payload
   } catch (error) {
     console.error('JWT verification failed', error)
-    return res.status(401).json({ message: 'Invalid or expired token' })
+    res.status(401).json({ message: 'Invalid or expired token' })
+    return null
   }
+}
+
+const authMiddleware = (req, res, next) => {
+  if (isPublicRoute(req.path)) {
+    return next()
+  }
+
+  const payload = authenticateRequest(req, res)
+  if (!payload) return null
 
   return next()
 }
 
+const requireRole = (allowedRoles) => (req, res, next) => {
+  if (!req.user) {
+    const payload = authenticateRequest(req, res)
+    if (!payload) return null
+  }
+
+  if (!allowedRoles.includes(req.user.role)) {
+    return res.status(403).json({ message: 'Insufficient permissions' })
+  }
+
+  refreshSessionContext(req, req.user)
+  return next()
+}
+
+const requireTeam = requireRole(['team'])
+const requireModerator = requireRole(['moderator', 'admin'])
+const requireAdmin = requireRole(['admin'])
+
 export default authMiddleware
+export { requireTeam, requireModerator, requireAdmin, addTokenToBlacklist, isTokenBlacklisted }

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,14 +1,32 @@
 import { Router } from 'express'
+import bcrypt from 'bcrypt'
 import { Moderator, Question, Team } from '../db/models/index.js'
 import { seedModerators, seedQuestions, seedTeams } from '../seeds/initialData.js'
 
 const adminRouter = Router()
 
+const hashRecordPassword = async (record = {}) => {
+  const preparedRecord = { ...record }
+  if (preparedRecord.passwordHash) {
+    return preparedRecord
+  }
+
+  if (!preparedRecord.password) {
+    return preparedRecord
+  }
+
+  preparedRecord.passwordHash = await bcrypt.hash(preparedRecord.password, 10)
+  delete preparedRecord.password
+  return preparedRecord
+}
+
 const upsertByLoginId = async (Model, payload, uniqueKey = 'loginId') => {
   const records = Array.isArray(payload) && payload.length > 0 ? payload : []
   if (records.length === 0) return { matchedCount: 0, upsertedCount: 0 }
 
-  const operations = records.map((doc) => ({
+  const recordsWithHash = await Promise.all(records.map((record) => hashRecordPassword(record)))
+
+  const operations = recordsWithHash.map((doc) => ({
     updateOne: {
       filter: { [uniqueKey]: doc[uniqueKey] },
       update: { $setOnInsert: doc },

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,0 +1,131 @@
+import { Router } from 'express'
+import bcrypt from 'bcrypt'
+import jwt from 'jsonwebtoken'
+import { Moderator, Team } from '../db/models/index.js'
+import { security } from '../config/index.js'
+import { addTokenToBlacklist } from '../middleware/auth.js'
+
+const authRouter = Router()
+const {
+  jwt: { secret, expiresIn },
+} = security
+
+const signToken = ({ id, loginId, role }) =>
+  jwt.sign({ sub: id, loginId, role }, secret, {
+    expiresIn,
+  })
+
+const sanitizeTeam = (teamDoc) => ({
+  id: teamDoc._id.toString(),
+  loginId: teamDoc.loginId,
+  name: teamDoc.name,
+  region: teamDoc.region,
+  seed: teamDoc.seed,
+  avatarUrl: teamDoc.avatarUrl,
+  metadata: teamDoc.metadata,
+})
+
+const sanitizeModerator = (moderatorDoc) => ({
+  id: moderatorDoc._id.toString(),
+  loginId: moderatorDoc.loginId,
+  email: moderatorDoc.email,
+  displayName: moderatorDoc.displayName,
+  role: moderatorDoc.role,
+  permissions: moderatorDoc.permissions,
+})
+
+const validateCredentials = (req, res) => {
+  const { loginId, password } = req.body || {}
+  if (!loginId || !password) {
+    res.status(400).json({ message: 'loginId and password are required' })
+    return null
+  }
+  return { loginId, password }
+}
+
+const comparePassword = async (providedPassword, storedHash) =>
+  bcrypt.compare(providedPassword, storedHash)
+
+authRouter.post('/team', async (req, res, next) => {
+  const credentials = validateCredentials(req, res)
+  if (!credentials) return
+
+  try {
+    const team = await Team.findOne({ loginId: credentials.loginId }).select('+passwordHash')
+    if (!team) {
+      return res.status(401).json({ message: 'Invalid credentials' })
+    }
+
+    const isValidPassword = await comparePassword(credentials.password, team.passwordHash)
+    if (!isValidPassword) {
+      return res.status(401).json({ message: 'Invalid credentials' })
+    }
+
+    const token = signToken({ id: team._id.toString(), loginId: team.loginId, role: 'team' })
+    res.json({ token, user: sanitizeTeam(team) })
+  } catch (error) {
+    next(error)
+  }
+})
+
+authRouter.post('/moderator', async (req, res, next) => {
+  const credentials = validateCredentials(req, res)
+  if (!credentials) return
+
+  try {
+    const moderator = await Moderator.findOne({ loginId: credentials.loginId, role: 'moderator', active: true }).select(
+      '+passwordHash'
+    )
+    if (!moderator) {
+      return res.status(401).json({ message: 'Invalid credentials' })
+    }
+
+    const isValidPassword = await comparePassword(credentials.password, moderator.passwordHash)
+    if (!isValidPassword) {
+      return res.status(401).json({ message: 'Invalid credentials' })
+    }
+
+    const token = signToken({ id: moderator._id.toString(), loginId: moderator.loginId, role: 'moderator' })
+    res.json({ token, user: sanitizeModerator(moderator) })
+  } catch (error) {
+    next(error)
+  }
+})
+
+authRouter.post('/admin', async (req, res, next) => {
+  const credentials = validateCredentials(req, res)
+  if (!credentials) return
+
+  try {
+    const admin = await Moderator.findOne({ loginId: credentials.loginId, role: 'admin', active: true }).select(
+      '+passwordHash'
+    )
+    if (!admin) {
+      return res.status(401).json({ message: 'Invalid credentials' })
+    }
+
+    const isValidPassword = await comparePassword(credentials.password, admin.passwordHash)
+    if (!isValidPassword) {
+      return res.status(401).json({ message: 'Invalid credentials' })
+    }
+
+    const token = signToken({ id: admin._id.toString(), loginId: admin.loginId, role: 'admin' })
+    res.json({ token, user: sanitizeModerator(admin) })
+  } catch (error) {
+    next(error)
+  }
+})
+
+authRouter.post('/logout', (req, res) => {
+  const authHeader = req.headers.authorization
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    return res.status(400).json({ message: 'No token provided' })
+  }
+
+  const token = authHeader.replace('Bearer ', '')
+  addTokenToBlacklist(token)
+  return res.json({ message: 'Logged out. Please delete any stored tokens.' })
+})
+
+export default authRouter

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { accounts, constants } from '../config/index.js'
 import adminRouter from './admin.js'
+import authRouter from './auth.routes.js'
 
 const router = Router()
 
@@ -22,6 +23,7 @@ router.get('/accounts/seed', (req, res) => {
   })
 })
 
+router.use('/auth', authRouter)
 router.use('/admin', adminRouter)
 
 export default router

--- a/backend/src/seeds/initialData.js
+++ b/backend/src/seeds/initialData.js
@@ -1,7 +1,7 @@
 export const seedTeams = [
-  { name: 'North City Bulls', loginId: 'team-north-bulls', region: 'North', seed: 1 },
-  { name: 'East Harbor Jets', loginId: 'team-east-jets', region: 'East', seed: 2 },
-  { name: 'South Bay Guardians', loginId: 'team-south-guardians', region: 'South', seed: 3 },
+  { name: 'North City Bulls', loginId: 'team-north-bulls', password: 'north-pass-123', region: 'North', seed: 1 },
+  { name: 'East Harbor Jets', loginId: 'team-east-jets', password: 'east-pass-123', region: 'East', seed: 2 },
+  { name: 'South Bay Guardians', loginId: 'team-south-guardians', password: 'south-pass-123', region: 'South', seed: 3 },
 ]
 
 export const seedModerators = [
@@ -9,13 +9,22 @@ export const seedModerators = [
     loginId: 'mod-avery',
     email: 'avery.moderator@financialfootball.test',
     displayName: 'Avery',
+    password: 'moderator123',
     role: 'moderator',
   },
   {
     loginId: 'mod-river',
     email: 'river.moderator@financialfootball.test',
     displayName: 'River',
+    password: 'moderator123',
     role: 'moderator',
+  },
+  {
+    loginId: 'admin-root',
+    email: 'admin@financialfootball.test',
+    displayName: 'Administrator',
+    password: process.env.ADMIN_PASSWORD || 'admin123',
+    role: 'admin',
   },
 ]
 


### PR DESCRIPTION
## Summary
- add JWT-based auth routes for teams, moderators, and admins with logout handling
- hash seeded account passwords with bcrypt and store password hashes on teams and moderators
- expose role guard middleware for downstream routes and register new auth router

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb2f0c6a88320ba3d31e675c5eef0)