### PR TITLE
Add persistent auth API layer and validation updates

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,149 @@
+const TOKEN_KEY = 'ffa_auth_token'
+
+function getHeaders(token, bodyProvided = true) {
+  const headers = bodyProvided ? { 'Content-Type': 'application/json' } : {}
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+async function postJson(url, body, token) {
+  const method = body ? 'POST' : 'GET'
+  const response = await fetch(url, {
+    method,
+    headers: getHeaders(token, Boolean(body)),
+    body: body ? JSON.stringify(body) : undefined,
+  })
+
+  const data = await response.json().catch(() => ({}))
+
+  if (!response.ok) {
+    const error = new Error(data.message || 'Request failed')
+    error.status = response.status
+    throw error
+  }
+
+  return data
+}
+
+export function getStoredToken() {
+  if (typeof localStorage === 'undefined') return null
+  return localStorage.getItem(TOKEN_KEY)
+}
+
+export function setStoredToken(token) {
+  if (typeof localStorage === 'undefined') return
+  if (token) {
+    localStorage.setItem(TOKEN_KEY, token)
+  } else {
+    localStorage.removeItem(TOKEN_KEY)
+  }
+}
+
+export function clearStoredToken() {
+  setStoredToken(null)
+}
+
+function decodeJwtPayload(token) {
+  if (!token || typeof token !== 'string') return null
+  const parts = token.split('.')
+  if (parts.length < 2) return null
+  try {
+    return JSON.parse(atob(parts[1]))
+  } catch (error) {
+    console.warn('Failed to decode token payload', error)
+    return null
+  }
+}
+
+async function loginWithRole(role, credentials) {
+  const endpoints = {
+    admin: '/auth/admin',
+    moderator: '/auth/moderator',
+    team: '/auth/team',
+  }
+
+  const endpoint = endpoints[role] || endpoints.team
+  const result = await postJson(endpoint, credentials)
+  if (result?.token) setStoredToken(result.token)
+  return result
+}
+
+export async function loginTeam(credentials) {
+  return loginWithRole('team', credentials)
+}
+
+export async function loginAdmin(credentials) {
+  return loginWithRole('admin', credentials)
+}
+
+export async function loginModerator(credentials) {
+  return loginWithRole('moderator', credentials)
+}
+
+export async function registerTeam(payload) {
+  return postJson('/auth/register', payload)
+}
+
+export async function registerModerator(payload) {
+  return postJson('/auth/register/moderator', payload)
+}
+
+export async function requestTeamPasswordReset(payload) {
+  return postJson('/auth/forgot-password/team', payload)
+}
+
+export async function requestModeratorPasswordReset(payload) {
+  return postJson('/auth/forgot-password/moderator', payload)
+}
+
+export async function fetchProfile(token) {
+  const authToken = token ?? getStoredToken()
+  if (!authToken) throw new Error('Missing auth token')
+
+  try {
+    return await postJson('/auth/me', null, authToken)
+  } catch (networkError) {
+    const decoded = decodeJwtPayload(authToken)
+    if (decoded) {
+      return { ...decoded, token: authToken }
+    }
+    throw networkError
+  }
+}
+
+export function deriveSessionFromProfile(data = {}) {
+  const user = data.user ?? data.profile ?? null
+  const normalizedRole = (data.type || data.role || user?.role || user?.accountType || user?.type || '')
+    .toString()
+    .toLowerCase()
+
+  let type = normalizedRole
+  if (!['team', 'admin', 'moderator'].includes(type)) {
+    if (user?.teamName || user?.organization) {
+      type = 'team'
+    }
+  }
+
+  const teamId = type === 'team' ? user?.id ?? user?.loginId ?? user?.teamId : undefined
+  const moderatorId = type === 'moderator' ? user?.id ?? user?.loginId ?? user?.moderatorId : undefined
+
+  return {
+    type: type || 'guest',
+    teamId,
+    moderatorId,
+    profile: user || null,
+    token: data.token ?? getStoredToken(),
+  }
+}
+
+export function createSessionFromAuthResponse(result, fallbackType) {
+  return deriveSessionFromProfile({ ...result, type: result?.type ?? fallbackType, token: result?.token })
+}
+
+export async function restoreSessionFromStorage() {
+  const token = getStoredToken()
+  if (!token) return null
+
+  const profileData = await fetchProfile(token)
+  return deriveSessionFromProfile({ ...profileData, token })
+}

--- a/frontend/src/components/AuthenticationGateway.jsx
+++ b/frontend/src/components/AuthenticationGateway.jsx
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 
+const MIN_PASSWORD_LENGTH = 6
+const isValidEmail = (value) => /\S+@\S+\.\S+/.test(value?.trim() ?? '')
+
 const BASE_MODES = [
   { id: 'team', label: 'User Login' }, // label to match screenshot
   { id: 'admin', label: 'Admin Login' },
@@ -100,6 +103,11 @@ export default function AuthenticationGateway({
       return
     }
 
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setLocalError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`)
+      return
+    }
+
     try {
       setLoginSubmitting(true)
       if (mode === 'team') await onTeamLogin(loginId, password)
@@ -172,10 +180,30 @@ export default function AuthenticationGateway({
         setRegisterError('Please complete all required team registration fields.')
         return
       }
+
+      if (!isValidEmail(contactEmail)) {
+        setRegisterError('Please provide a valid contact email address.')
+        return
+      }
+
+      if (password.trim().length < MIN_PASSWORD_LENGTH) {
+        setRegisterError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`)
+        return
+      }
     } else {
       const { loginId, email, password } = moderatorRegisterForm
       if (!loginId.trim() || !email.trim() || !password.trim()) {
         setRegisterError('Please complete all required moderator registration fields.')
+        return
+      }
+
+      if (!isValidEmail(email)) {
+        setRegisterError('Please provide a valid moderator email address.')
+        return
+      }
+
+      if (password.trim().length < MIN_PASSWORD_LENGTH) {
+        setRegisterError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`)
         return
       }
     }
@@ -231,6 +259,16 @@ export default function AuthenticationGateway({
 
     if (!loginId || !newPassword || (forgotMode === 'moderator' && !emailField)) {
       setForgotError('Please provide the required details to reset your password.')
+      return
+    }
+
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      setForgotError(`New password must be at least ${MIN_PASSWORD_LENGTH} characters.`)
+      return
+    }
+
+    if (emailField && !isValidEmail(emailField)) {
+      setForgotError('Please enter a valid email address for verification.')
       return
     }
 

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,7 +1,11 @@
 import { Navigate, useLocation } from 'react-router-dom'
 
-export default function ProtectedRoute({ isAllowed, redirectTo = '/', children }) {
+export default function ProtectedRoute({ isAllowed, redirectTo = '/', isLoading = false, children }) {
   const location = useLocation()
+
+  if (isLoading) {
+    return null
+  }
 
   if (!isAllowed) {
     return <Navigate to={redirectTo} replace state={{ from: location }} />


### PR DESCRIPTION
## Summary
- add a dedicated frontend auth API module for login, registration, password resets, and token persistence
- initialize app session state from stored tokens, fetch current profile, and gate protected routes during restoration
- tighten AuthenticationGateway validations across login, registration, and password reset flows

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ddf327c48320805c014ff04868b2)