### PR TITLE
Add logout API support to frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,9 +28,11 @@ import PublicMatchViewer from './components/PublicMatchViewer'
 import {
   clearStoredToken,
   createSessionFromAuthResponse,
+  getStoredToken,
   loginAdmin,
   loginModerator,
   loginTeam,
+  logout,
   registerModerator,
   registerTeam,
   requestModeratorPasswordReset,
@@ -509,11 +511,22 @@ function AppShell() {
     return requestModeratorPasswordReset(payload)
   }
 
-  const handleLogout = () => {
-    clearStoredToken()
-    setSession({ type: 'guest' })
-    setAuthError(null)
-    navigate('/', { replace: true })
+  const handleLogout = async () => {
+    const token = session?.token ?? getStoredToken()
+
+    try {
+      if (token) {
+        await logout(token)
+      }
+    } catch (error) {
+      console.error('Logout failed', error)
+    } finally {
+      clearStoredToken()
+      setSession({ type: 'guest', token: null, profile: null, teamId: null, moderatorId: null })
+      setSessionReady(true)
+      setAuthError(null)
+      navigate('/', { replace: true })
+    }
   }
 
   useEffect(() => {

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -96,6 +96,13 @@ export async function requestModeratorPasswordReset(payload) {
   return postJson('/auth/forgot-password/moderator', payload)
 }
 
+export async function logout(token) {
+  const authToken = token ?? getStoredToken()
+  if (!authToken) throw new Error('Missing auth token')
+
+  return postJson('/auth/logout', {}, authToken)
+}
+
 export async function fetchProfile(token) {
   const authToken = token ?? getStoredToken()
   if (!authToken) throw new Error('Missing auth token')


### PR DESCRIPTION
## Summary
- add an auth logout API helper that posts the bearer token to /auth/logout
- invoke the logout API from the logout handler while clearing stored auth state and redirecting to the landing page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e3adcbec8320a86886272f084187)